### PR TITLE
Add `custom_config.configMapOverride` to `astro` chart

### DIFF
--- a/stable/astro/Chart.yaml
+++ b/stable/astro/Chart.yaml
@@ -1,5 +1,5 @@
 name: astro
-version: 1.0.8
+version: 1.1.0
 apiVersion: v1
 appVersion: "1.5.3"
 description: Emit datadog monitors based on kubernetes state.

--- a/stable/astro/templates/configmap-data.yaml
+++ b/stable/astro/templates/configmap-data.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.custom_config.enabled }}
+{{- if and .Values.custom_config.enabled (not .Values.custom_config.configMapOverride) }}
 kind: ConfigMap
 apiVersion: v1
 metadata:

--- a/stable/astro/templates/configmap.yaml
+++ b/stable/astro/templates/configmap.yaml
@@ -11,7 +11,15 @@ data:
   OWNER: {{ .Values.owner }}
   DRY_RUN: {{ .Values.dryRun | quote }}
 {{- if .Values.custom_config.enabled }}
+  {{- if .Values.custom_config.configMapOverride }}
+    {{- $paths := list }}
+    {{- range .Values.custom_config.configMapOverride.rulesetFiles }}
+      {{- $paths = printf "/etc/config/%s" . | append $paths }}
+    {{- end }}
+  DEFINITIONS_PATH: {{ join ";" $paths }}
+  {{- else }}
   DEFINITIONS_PATH: /etc/config/config.yml
+  {{- end }}
 {{- else }}
   DEFINITIONS_PATH: {{ .Values.definitionsPath }}
 {{- end }}

--- a/stable/astro/templates/deployment.yaml
+++ b/stable/astro/templates/deployment.yaml
@@ -60,7 +60,11 @@ spec:
       volumes:
       - name: config-data
         configMap:
+          {{- if .Values.custom_config.configMapOverride }}
+          name: {{ index .Values.custom_config.configMapOverride "name" }}
+          {{- else }}
           name: {{ include "astro.fullname" . }}-data
+          {{- end }}
           {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/stable/astro/values.yaml
+++ b/stable/astro/values.yaml
@@ -53,8 +53,21 @@ owner: astro
 # -- When set to true monitors will not be managed in datadog.
 dryRun: false
 custom_config:
-  # -- If true a custom configuration must be specified in `custom_config.data`.
+  # -- If true a custom configuration must be specified in one of:
+  #   custom_config.data
+  #   custom_config.configMapOverride
   enabled: false
+  # -- Custom ConfigMap override allowing a parent chart to define its own ConfigMap that astro mounts into its Pods.
+  #
+  # `configMapOverride` is mutually exclusive with `data`
+  #
+  # Structure:
+  #   configMapOverride:
+  #     name: other-config-map # Must not contain uppercase letters
+  #     rulesetFiles:
+  #       - ruleset-1.yaml
+  #       - ruleset-2.yaml
+  configMapOverride:
   # -- An astro configuration file. See the [Astro repo readme](https://github.com/fairwindsops/astro) for more details.
   # @default -- ""
   data: |


### PR DESCRIPTION
### Note
This PR is against _**my fork**_, not the upstream branch.

### Summary
This PR enables parent charts of `astro` to create & supply their own ConfigMap override that defines custom Astro rulesets.

Prior to this change, all custom rulesets supplied to the `astro` chart would either need to:
* **A)** Concatenate all rulesets as a single scalar inside `custom_config.data`

OR

* **B)** Store the custom rulesets at an accessible URL for Astro to query

### Example
This section demonstrates how a chart `foo`, which depends on chart `astro`, could use the new ConfigMap override functionality.

<details>
  <summary>Click to expand!</summary>

`foo/Chart.yaml`
```
apiVersion: v2
name: foo
...
dependencies:
  - name: astro
    version: 1.1.0
    repository: <repository>
```

`foo/values.yaml`
```
astro:
  custom_config:
    enabled: true
    configMapOverride:
      name: astro-config-map-override
      rulesetFiles:
        - pod-rulesets.yaml
        - ingress-rulesets.yaml
```

`foo/templates/configmap-override.yaml`
```
{{- if .Values.astro.custom_config.enabled }}
  {{- if .Values.astro.custom_config.configMapOverride }}
    {{- $configMapOverride := .Values.astro.custom_config.configMapOverride }}
kind: ConfigMap
apiVersion: v1
metadata:
  name: {{ index $configMapOverride "name" }}
data:
    {{- $files := .Files }}
    {{- range (index $configMapOverride "rulesetFiles") }}
      {{- $ruleset := $files.Get . }}
  {{ . }}: {{ toYaml $ruleset | indent 2 }}
    {{- end }}
  {{- end }}
{{- end }}
```

`foo/pod-rulesets.yaml`
```
rulesets:
- type: deployment
  match_annotations:
    - name: astro/ruleset-pod-status
      value: true
  monitors:
    pod-status-alert:
      name: >-
        Pod Status: {{ .ObjectMeta.Name }}
      type: metric alert
      ...
```

</details>